### PR TITLE
Add a C# client supporting Tanks over UDP

### DIFF
--- a/WebContent/static/mainPage.jsp
+++ b/WebContent/static/mainPage.jsp
@@ -77,6 +77,7 @@
 				<div class="list-group">
 					<a class="list-group-item" href="${root}/static/script-wars-client.jar">Java library</a>
 					<a class="list-group-item" href="${root}/static/script-wars-python.zip">Python library</a>
+					<a class="list-group-item" href="${root}/static/script-wars-csharp.zip">C# library</a>
 				</div>
 			</div>
 			</div>

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,13 @@ task clientJar(type: Jar) {
 	destinationDir = file("$buildDir/war/static")
 }
 
+task clientCSharp(type: Zip) {
+	archiveName 'script-wars-csharp.zip'
+	
+	from "client/csharp";
+	destinationDir = file("$buildDir/war/static")
+}
+
 task standaloneJar(type: Jar) {
 	archiveName 'standaloneJudge.jar'
 
@@ -99,6 +106,7 @@ javadoc {
 war {
 	dependsOn clientJar
 	dependsOn clientPython
+	dependsOn clientCSharp
 	dependsOn javadoc
 	
 	archiveName 'ROOT.war'

--- a/client/csharp/Script Wars Client/Script Wars AI/Script Wars AI.csproj
+++ b/client/csharp/Script Wars Client/Script Wars AI/Script Wars AI.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Script Wars Client\Script Wars Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/client/csharp/Script Wars Client/Script Wars AI/ScriptWars/Games/Tanks/PlayerBots/RandomAi.cs
+++ b/client/csharp/Script Wars Client/Script Wars AI/ScriptWars/Games/Tanks/PlayerBots/RandomAi.cs
@@ -1,0 +1,81 @@
+﻿using System;
+
+namespace ScriptWars.Games.Tanks.PlayerBots
+{
+    /// <summary>
+    /// Example Script Wars tanks AI using the C# client.
+    /// </summary>
+    public class RandomAi
+    {
+        public static void Main(string[] args)
+        {
+            int id;
+
+            // Try parse ID from args
+            if (!(args.Length > 0 && int.TryParse(args[0], out id)))
+            {
+                // Try get ID from console input
+                bool parsed;
+
+                do
+                {
+                    Console.WriteLine("Enter ID: ");
+                    parsed = int.TryParse(Console.ReadLine(), out id);
+                } while (!parsed);
+            }
+
+            var ai = new RandomAi(id);
+            ai.Run();
+        }
+        
+        private readonly TankApi _api;
+        private readonly Random _random = new Random();
+
+        private RandomAi(int id)
+        {
+            _api = new TankApi(id, "www.script-wars.com", "C# Random AI");
+        }
+
+        private void Run()
+        {
+            var directionCount = Enum.GetValues(typeof(Direction)).Length;
+            
+            while (_api.NextTick())
+            {
+                if (!_api.IsAlive)
+                {
+                    // Dead this tick
+                    continue;
+                }
+
+                // Pick a random non-wall and non-tank direction to move in
+                Direction direction;
+                Coordinates newPosition;
+                do
+                {
+                    direction = (Direction) _random.Next(directionCount);
+                    newPosition = direction.Move(_api.Position);
+                } while (_api.Map.IsWall(newPosition) || _api.Map.GetTank(newPosition) != null);
+
+                _api.Move(direction);
+
+                // Try shoot at someone if there's ammo
+                if (_api.Ammo > 0)
+                {
+                    foreach (var tank in _api.VisibleTanks)
+                    {
+                        var targetDirection = DirectionExtensions.GetDirection(_api.Position, tank.Position);
+
+                        // Check for cardinal direction shot, shoot if we can
+                        if (targetDirection.HasValue)
+                        {
+                            _api.Shoot(targetDirection.Value);
+                        }
+                    }
+                }
+
+                _api.PrintAction();
+            }
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client.sln
+++ b/client/csharp/Script Wars Client/Script Wars Client.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.0.0
+MinimumVisualStudioVersion = 10.0.0.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptWarsClient", "Script Wars Client\Script Wars Client.csproj", "{BC567496-BCFC-4CC9-940D-3B392D71B3CE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/client/csharp/Script Wars Client/Script Wars Client.sln
+++ b/client/csharp/Script Wars Client/Script Wars Client.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptWarsClient", "Script Wars Client\Script Wars Client.csproj", "{BC567496-BCFC-4CC9-940D-3B392D71B3CE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Script Wars AI", "Script Wars AI\Script Wars AI.csproj", "{38F9AB35-449A-47AC-8CBB-A892FCFC49AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC567496-BCFC-4CC9-940D-3B392D71B3CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38F9AB35-449A-47AC-8CBB-A892FCFC49AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38F9AB35-449A-47AC-8CBB-A892FCFC49AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38F9AB35-449A-47AC-8CBB-A892FCFC49AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38F9AB35-449A-47AC-8CBB-A892FCFC49AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/client/csharp/Script Wars Client/Script Wars Client/Script Wars Client.csproj
+++ b/client/csharp/Script Wars Client/Script Wars Client/Script Wars Client.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Syroot.IO.BinaryData" Version="2.0.2" />
+  </ItemGroup>
+</Project>

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Connection.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Connection.cs
@@ -3,19 +3,23 @@ using System.Text;
 
 namespace ScriptWars.Connection
 {
-    public abstract class Connection
+    /// <summary>
+    /// Base connection to Script Wars server.
+    /// </summary>
+    /// <author></author>
+    internal abstract class Connection
     {
         private const int SuccessResponseCode = 0;
         private const int ErrorResponseCode = 1;
         private const int FailedToKeepUpResponseCode = 2;
         private const int ErrorInBufferResponseCode = 255;
-        
+
         /// <summary>
         /// Send data to the connected Script Wars server.
         /// </summary>
         /// <param name="data">Data to send.</param>
         public abstract void SendData(byte[] data);
-        
+
         /// <summary>
         /// Receive data from the connected Script Wars server.
         /// </summary>
@@ -30,23 +34,23 @@ namespace ScriptWars.Connection
         protected void CheckResponseCode(BinaryReader responseReader)
         {
             var responseCode = responseReader.ReadByte();
-            
+
             switch (responseCode)
             {
                 case ErrorResponseCode:
                     throw new ConnectionException(ConnectionStatus.Disconnected);
-                    
+
                 case FailedToKeepUpResponseCode:
                     throw new ConnectionException(ConnectionStatus.FailedToKeepUp);
-                    
+
                 case ErrorInBufferResponseCode:
                     var length = responseReader.ReadInt16();
                     var messageBytes = responseReader.ReadBytes(length);
                     throw new ConnectionException(ConnectionStatus.Error, Encoding.UTF8.GetString(messageBytes));
-                    
+
                 case SuccessResponseCode:
                     break;
-                    
+
                 default:
                     throw new ConnectionException(ConnectionStatus.Error, "Unknown response code " + responseCode);
             }

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Connection.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Connection.cs
@@ -1,0 +1,55 @@
+﻿using System.IO;
+using System.Text;
+
+namespace ScriptWars.Connection
+{
+    public abstract class Connection
+    {
+        private const int SuccessResponseCode = 0;
+        private const int ErrorResponseCode = 1;
+        private const int FailedToKeepUpResponseCode = 2;
+        private const int ErrorInBufferResponseCode = 255;
+        
+        /// <summary>
+        /// Send data to the connected Script Wars server.
+        /// </summary>
+        /// <param name="data">Data to send.</param>
+        public abstract void SendData(byte[] data);
+        
+        /// <summary>
+        /// Receive data from the connected Script Wars server.
+        /// </summary>
+        /// <returns>Reader for response.</returns>
+        public abstract BinaryReader WaitForData();
+
+        /// <summary>
+        /// Test the response code sent by the server in the first byte.
+        /// </summary>
+        /// <param name="responseReader">Reader for response stream from server.</param>
+        /// <exception cref="ConnectionException">Thrown when connection error has occurred.</exception>
+        protected void CheckResponseCode(BinaryReader responseReader)
+        {
+            var responseCode = responseReader.ReadByte();
+            
+            switch (responseCode)
+            {
+                case ErrorResponseCode:
+                    throw new ConnectionException(ConnectionStatus.Disconnected);
+                    
+                case FailedToKeepUpResponseCode:
+                    throw new ConnectionException(ConnectionStatus.FailedToKeepUp);
+                    
+                case ErrorInBufferResponseCode:
+                    var length = responseReader.ReadInt16();
+                    var messageBytes = responseReader.ReadBytes(length);
+                    throw new ConnectionException(ConnectionStatus.Error, Encoding.UTF8.GetString(messageBytes));
+                    
+                case SuccessResponseCode:
+                    break;
+                    
+                default:
+                    throw new ConnectionException(ConnectionStatus.Error, "Unknown response code " + responseCode);
+            }
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/ConnectionException.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/ConnectionException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace ScriptWars.Connection
+{
+    public class ConnectionException : Exception
+    {
+        public ConnectionStatus ConnectionStatus { get; }
+
+        public ConnectionException(ConnectionStatus connectionStatus, Exception innerException) :
+            base(connectionStatus.ToString(), innerException)
+        {
+            ConnectionStatus = connectionStatus;
+        }
+
+        public ConnectionException(ConnectionStatus connectionStatus, string message = null) : base(
+            message ?? connectionStatus.ToString())
+        {
+            ConnectionStatus = connectionStatus;
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/ConnectionStatus.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/ConnectionStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace ScriptWars.Connection
+{
+    public enum ConnectionStatus
+    {
+        Connected,
+        NotConnected,
+        Disconnected,
+        Dropped,
+        FailedToKeepUp,
+        Error
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
@@ -6,12 +6,23 @@ using Syroot.BinaryData;
 
 namespace ScriptWars.Connection
 {
+    /// <summary>
+    /// Manages a network connection to the Script Wars server.
+    /// </summary>
     public class Network
     {
+        /// <summary>
+        /// Buffer size to use for responses from the server.
+        /// </summary>
         private const int MaxOutputSize = 1024;
+
         private const int UdpProtocol = 1;
-        private const int UdpPort = 35565;
         private const int TcpProtocol = 2;
+
+        /// <summary>
+        /// Server port to use for <see cref="UdpConnection"/>.
+        /// </summary>
+        private const int UdpPort = 35565;
 
         private readonly int _id;
         private readonly Connection _connection;
@@ -168,6 +179,10 @@ namespace ScriptWars.Connection
             return boolValue;
         }
 
+        /// <summary>
+        /// Read a short from the last server tick.
+        /// </summary>
+        /// <returns>Short from response.</returns>
         public short ReadShort()
         {
             return _dataIn.ReadInt16();

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using Syroot.BinaryData;
+
+namespace ScriptWars.Connection
+{
+    public class Network
+    {
+        private const int MaxOutputSize = 1024;
+        private const int UdpProtocol = 1;
+        private const int UdpPort = 35565;
+        private const int TcpProtocol = 2;
+
+        private readonly int _id;
+        private readonly Connection _connection;
+
+        // Track boolean squashing
+        private int _boolBit = 0x100;
+
+        private long _boolBytePosition;
+
+        // Input and output streams
+        private MemoryStream _dataOutStream;
+
+        private BinaryWriter _dataOut;
+        private BinaryReader _dataIn;
+
+        /// <summary>
+        /// Latest status of the connection to the Script Wars server.
+        /// </summary>
+        public ConnectionStatus ConnectionStatus { get; private set; } = ConnectionStatus.NotConnected;
+
+        /// <summary>
+        /// Whether or not the server response stream has more data to process.
+        /// </summary>
+        public bool HasData => _dataIn.BaseStream.Position < _dataIn.BaseStream.Length;
+
+        /// <summary>
+        /// Create network connection to Script Wars server using issued ID. 
+        /// </summary>
+        /// <param name="botId">ID issued by the server website.</param>
+        /// <param name="serverAddress">IP or domain name of Script Wars server.</param>
+        /// <param name="botName">Name of your bot.</param>
+        /// <exception cref="NotImplementedException">TCP client is not available yet.</exception>
+        /// <exception cref="ArgumentException">Invalid ID provided.</exception>
+        public Network(int botId, string serverAddress, string botName)
+        {
+            _id = botId;
+
+            InitialiseOutBuffer();
+            Send(botName);
+
+            var protocol = botId >> 16 & 0xff;
+            switch (protocol)
+            {
+                case UdpProtocol:
+                    _connection = new UdpConnection(new DnsEndPoint(serverAddress, UdpPort));
+                    break;
+
+                case TcpProtocol:
+                    throw new NotImplementedException();
+
+                default:
+                    throw new ArgumentException("Invalid bot ID");
+            }
+        }
+
+        private void InitialiseOutBuffer()
+        {
+            _dataOutStream = new MemoryStream(MaxOutputSize);
+            _dataOut = new BinaryDataWriter(_dataOutStream)
+            {
+                ByteOrder = ByteOrder.BigEndian,
+            };
+            _dataOut.Write(_id);
+        }
+
+        /// <summary>
+        /// Waits until all the players have made their moves and sends the data and retrieved a new set of data from 
+        /// the server. This method returns false if the game is over or you have timed out.
+        /// </summary>
+        /// <returns>
+        /// False if the client was disconnected or timed out. The exact cause can be found by checking 
+        /// <see cref="ConnectionStatus"/>. Once this method returns false please attempt to re-use the connection.
+        /// </returns>
+        public bool NextTick()
+        {
+            try
+            {
+                ConnectionStatus = ConnectionStatus.Connected;
+                _dataOutStream.SetLength(MaxOutputSize);
+
+                var f = new FileInfo("D://hardai_cs.out");
+
+                using (var outstream = f.OpenWrite())
+                {
+                    var b = _dataOutStream.ToArray();
+                    outstream.Write(b, 0, b.Length);
+                }
+
+                _connection.SendData(_dataOutStream.ToArray());
+                InitialiseOutBuffer();
+
+                _dataIn = _connection.WaitForData();
+            }
+            catch (ConnectionException e)
+            {
+                Console.WriteLine(e);
+                ConnectionStatus = e.ConnectionStatus;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Read a 32-bit integer from the last server tick.
+        /// </summary>
+        /// <returns>Integer from the server response.</returns>
+        public int ReadInt()
+        {
+            return _dataIn.ReadInt32();
+        }
+
+        /// <summary>
+        /// Read a floating point number from the last server tick.
+        /// </summary>
+        /// <returns>Float from the server response.</returns>
+        public float ReadFloat()
+        {
+            return _dataIn.ReadSingle();
+        }
+
+        /// <summary>
+        /// Read a byte from the last server tick.
+        /// </summary>
+        /// <returns>Byte from response.</returns>
+        public byte ReadByte()
+        {
+            return _dataIn.ReadByte();
+        }
+
+        /// <summary>
+        /// Read a boolean from the server response. Booleans are encoded as bits inside a byte, allowing the storage 
+        /// of eight booleans each byte.
+        /// </summary>
+        /// <returns>Next boolean from the server response.</returns>
+        public bool ReadBool()
+        {
+            var inStream = _dataIn.BaseStream;
+            var streamOriginalPosition = inStream.Position;
+
+            if (_boolBit == 0x100 || _boolBytePosition != streamOriginalPosition - 1)
+            {
+                _boolBit = 1;
+                _boolBytePosition = streamOriginalPosition;
+                streamOriginalPosition++;
+            }
+
+            int currentByte = _dataIn.ReadByte();
+            var boolValue = (currentByte & _boolBit) != 0;
+
+            inStream.Seek(streamOriginalPosition, SeekOrigin.Begin);
+            _boolBit <<= 1;
+
+            return boolValue;
+        }
+
+        public short ReadShort()
+        {
+            return _dataIn.ReadInt16();
+        }
+
+        /// <summary>
+        /// Read a string from the last server tick.
+        /// </summary>
+        /// <returns>String from response.</returns>
+        public string ReadString()
+        {
+            int length = ReadShort();
+            var strBytes = _dataIn.ReadBytes(length);
+            return Encoding.UTF8.GetString(strBytes);
+        }
+
+        /// <summary>
+        /// Get raw data from the last server tick.
+        /// </summary>
+        /// <returns>Byte array of server's response.</returns>
+        public byte[] GetRawData()
+        {
+            return ((MemoryStream) _dataIn.BaseStream).ToArray();
+        }
+
+        /// <summary>
+        /// Send a 32-bit integer to the server.
+        /// </summary>
+        /// <param name="i">Integer to send.</param>
+        public void Send(int i)
+        {
+            _dataOut.Write(i);
+        }
+
+        /// <summary>
+        /// Send a floating point number to the server.
+        /// </summary>
+        /// <param name="f">Float to send.</param>
+        public void Send(float f)
+        {
+            _dataOut.Write(f);
+        }
+
+        /// <summary>
+        /// Send a byte to the server.
+        /// </summary>
+        /// <param name="b">Byte to send.</param>
+        public void Send(byte b)
+        {
+            _dataOut.Write(b);
+        }
+
+        /// <summary>
+        /// Send a 16-bit integer to the server.
+        /// </summary>
+        /// <param name="s">Short to send.</param>
+        public void Send(short s)
+        {
+            _dataOut.Write(s);
+        }
+
+        /// <summary>
+        /// Send a string to the server.
+        /// </summary>
+        /// <param name="s">String to send.</param>
+        public void Send(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            Send((short) bytes.Length);
+            Send(bytes);
+        }
+
+        /// <summary>
+        /// Send raw data to the server.
+        /// </summary>
+        /// <param name="bytes">Bytes to send.</param>
+        public void Send(byte[] bytes)
+        {
+            _dataOut.Write(bytes);
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/Network.cs
@@ -170,10 +170,10 @@ namespace ScriptWars.Connection
                 streamOriginalPosition++;
             }
 
+            inStream.Seek(_boolBytePosition, SeekOrigin.Begin);
             int currentByte = _dataIn.ReadByte();
             var boolValue = (currentByte & _boolBit) != 0;
 
-            inStream.Seek(streamOriginalPosition, SeekOrigin.Begin);
             _boolBit <<= 1;
 
             return boolValue;

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/UdpConnection.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Connection/UdpConnection.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using Syroot.BinaryData;
+
+namespace ScriptWars.Connection
+{
+    internal class UdpConnection : Connection
+    {
+        private const int BufferSizeBytes = 1024;
+        private const int SocketTimeoutMs = 1500;
+
+        private readonly Socket _socket;
+
+        public UdpConnection(EndPoint dnsEndPoint)
+        {
+            _socket = new Socket(SocketType.Dgram, ProtocolType.Udp)
+            {
+                SendTimeout = SocketTimeoutMs,
+                ReceiveTimeout = SocketTimeoutMs
+            };
+            _socket.Connect(dnsEndPoint);
+        }
+
+        public override void SendData(byte[] data)
+        {
+            try
+            {
+                _socket.Send(data);
+            }
+            catch (Exception e)
+            {
+                throw new ConnectionException(ConnectionStatus.Dropped, e);
+            }
+        }
+
+        public override BinaryReader WaitForData()
+        {
+            BinaryReader reader;
+
+            try
+            {
+                var buffer = new byte[BufferSizeBytes];
+                _socket.Receive(buffer);
+                var bufferStream = new MemoryStream(buffer, true);
+                reader = new BinaryDataReader(bufferStream)
+                {
+                    ByteOrder = ByteOrder.BigEndian,
+                };
+            }
+            catch (Exception e)
+            {
+                throw new ConnectionException(ConnectionStatus.Dropped, e);
+            }
+
+            CheckResponseCode(reader);
+            return reader;
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Action.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Action.cs
@@ -1,0 +1,9 @@
+﻿namespace ScriptWars.Games.Tanks
+{
+    public enum Action
+    {
+        Nothing = 0,
+        Move = 1,
+        Shoot = 2
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Action.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Action.cs
@@ -1,5 +1,8 @@
 ﻿namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// Tank action options.
+    /// </summary>
     public enum Action
     {
         Nothing = 0,

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
@@ -17,7 +17,7 @@ namespace ScriptWars.Games.Tanks
         /// <param name="y">Y coordinate.</param>
         public Coordinates(int x, int y)
         {
-            X = y;
+            X = x;
             Y = y;
         }
 

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
@@ -2,18 +2,30 @@
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// A single map position.
+    /// </summary>
     public class Coordinates
     {
         public readonly int X;
         public readonly int Y;
 
+        /// <summary>
+        /// Create a coordinate from its map position.
+        /// </summary>
+        /// <param name="x">X coordinate.</param>
+        /// <param name="y">Y coordinate.</param>
         public Coordinates(int x, int y)
         {
             X = y;
             Y = y;
         }
 
-        public Coordinates(Network network) : this(network.ReadByte(), network.ReadByte())
+        /// <summary>
+        /// Read a coordinate from the server tick response.
+        /// </summary>
+        /// <param name="network"><see cref="Network"/> to use to fetch data.</param>
+        internal Coordinates(Network network) : this(network.ReadByte(), network.ReadByte())
         {
         }
 

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Coordinates.cs
@@ -1,0 +1,50 @@
+﻿using ScriptWars.Connection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public class Coordinates
+    {
+        public readonly int X;
+        public readonly int Y;
+
+        public Coordinates(int x, int y)
+        {
+            X = y;
+            Y = y;
+        }
+
+        public Coordinates(Network network) : this(network.ReadByte(), network.ReadByte())
+        {
+        }
+
+        #region Equality
+
+        protected bool Equals(Coordinates other)
+        {
+            return X == other.X && Y == other.Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((Coordinates) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return X ^ (Y * 31);
+            }
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return $"({X}, {Y})";
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Direction.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Direction.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public enum Direction
+    {
+        [DirectionData(0, -1)] Up,
+        [DirectionData(-1, 0)] Left,
+        [DirectionData(0, 1)] Down,
+        [DirectionData(1, 0)] Right
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    internal class DirectionData : Attribute
+    {
+        public readonly int Dx;
+        public readonly int Dy;
+
+        public DirectionData(int dx, int dy)
+        {
+            Dx = dx;
+            Dy = dy;
+        }
+    }
+
+    public static class DirectionExtensions
+    {
+        private static IEnumerable<T> GetAttributes<T>(Enum value) where T : Attribute
+        {
+            var fieldInfo = value.GetType().GetRuntimeField(value.ToString());
+            return fieldInfo.GetCustomAttributes(typeof(T)).Cast<T>();
+        }
+        
+        internal static DirectionData GetDirectionData(this Direction direction)
+        {
+            return GetAttributes<DirectionData>(direction).First();
+        }
+        
+        public static int MoveX(this Direction direction, int x)
+        {
+            return x + direction.GetDirectionData().Dx;
+        }
+
+        public static int MoveY(this Direction direction, int y)
+        {
+            return y + direction.GetDirectionData().Dy;
+        }
+
+        public static Coordinates Move(this Direction direction, Coordinates coordinates)
+        {
+            return new Coordinates(direction.MoveX(coordinates.X), direction.MoveY(coordinates.Y));
+        }
+
+        public static Direction Opposite(this Direction direction)
+        {
+            return (Direction) ((int)direction + 2 % 4);
+        }
+
+        public static Direction Clockwise(this Direction direction)
+        {
+            return (Direction) ((int)direction + 3 % 4);
+        }
+        
+        public static Direction Anticlockwise(this Direction direction)
+        {
+            return (Direction) ((int)direction + 1 % 4);
+        }
+
+        public static Direction? GetDirection(int x, int y)
+        {
+            if(x > 0 && y == 0) return Direction.Right;
+            if(x < 0 && y == 0) return Direction.Left;
+            if(x == 0 && y < 0) return Direction.Up;
+            if(x == 0 && y > 0) return Direction.Down;
+
+            return null;
+        }
+
+        public static Direction? GetDirection(Coordinates targetPosition, Coordinates myPosition)
+        {
+            return GetDirection(targetPosition.X - myPosition.X, targetPosition.Y - myPosition.Y);
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Direction.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Direction.cs
@@ -5,6 +5,9 @@ using System.Reflection;
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// Directions <see cref="Tank"/> and <see cref="Shot"/> can move in.
+    /// </summary>
     public enum Direction
     {
         [DirectionData(0, -1)] Up,
@@ -13,6 +16,9 @@ namespace ScriptWars.Games.Tanks
         [DirectionData(1, 0)] Right
     }
 
+    /// <summary>
+    /// Annotate X and Y velocities of a <see cref="Direction"/>.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     internal class DirectionData : Attribute
     {
@@ -28,58 +34,118 @@ namespace ScriptWars.Games.Tanks
 
     public static class DirectionExtensions
     {
+        /// <summary>
+        /// Read an enum value's first attribute of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="value">Enum to read attribute of.</param>
+        /// <typeparam name="T">Attribute type to read.</typeparam>
+        /// <returns>Attribute data from that enum value.</returns>
         private static IEnumerable<T> GetAttributes<T>(Enum value) where T : Attribute
         {
             var fieldInfo = value.GetType().GetRuntimeField(value.ToString());
             return fieldInfo.GetCustomAttributes(typeof(T)).Cast<T>();
         }
-        
+
+        /// <summary>
+        /// Get <see cref="DirectionData"/> attribute of a Direction enum value.
+        /// </summary>
+        /// <param name="direction">Direction to read attribute for.</param>
+        /// <returns></returns>
         internal static DirectionData GetDirectionData(this Direction direction)
         {
             return GetAttributes<DirectionData>(direction).First();
         }
-        
+
+        /// <summary>
+        /// Apply a <see cref="Direction"/> movement to an X coordinate.
+        /// </summary>
+        /// <param name="direction">Direction to apply.</param>
+        /// <param name="x">Original coordinate.</param>
+        /// <returns>Moved X coordinate.</returns>
         public static int MoveX(this Direction direction, int x)
         {
             return x + direction.GetDirectionData().Dx;
         }
 
+        /// <summary>
+        /// Apply a <see cref="Direction"/> movement to a Y coordinate.
+        /// </summary>
+        /// <param name="direction">Direction to apply.</param>
+        /// <param name="y">Original coordinate.</param>
+        /// <returns>Moved Y coordinate.</returns>
         public static int MoveY(this Direction direction, int y)
         {
             return y + direction.GetDirectionData().Dy;
         }
 
+        /// <summary>
+        /// Apply a direction movement to a <see cref="Coordinates" />.
+        /// </summary>
+        /// <param name="direction"></param>
+        /// <param name="coordinates"></param>
+        /// <returns></returns>
         public static Coordinates Move(this Direction direction, Coordinates coordinates)
         {
             return new Coordinates(direction.MoveX(coordinates.X), direction.MoveY(coordinates.Y));
         }
 
+        /// <summary>
+        /// Find the opposite of this <see cref="Direction"/>.
+        /// </summary>
+        /// <param name="direction">Direction to find opposite of.</param>
+        /// <returns>Opposite direction.</returns>
         public static Direction Opposite(this Direction direction)
         {
-            return (Direction) ((int)direction + 2 % 4);
+            return (Direction) ((int) direction + 2 % 4);
         }
 
+        /// <summary>
+        /// Find the next clockwise <see cref="Direction"/> to <paramref name="direction"/>.
+        /// </summary>
+        /// <param name="direction">Direction to turn clockwise.</param>
+        /// <returns>Clockwise direction.</returns>
         public static Direction Clockwise(this Direction direction)
         {
-            return (Direction) ((int)direction + 3 % 4);
-        }
-        
-        public static Direction Anticlockwise(this Direction direction)
-        {
-            return (Direction) ((int)direction + 1 % 4);
+            return (Direction) ((int) direction + 3 % 4);
         }
 
+        /// <summary>
+        /// Find the next anti-clockwise <see cref="Direction"/> to <paramref name="direction"/>.
+        /// </summary>
+        /// <param name="direction">Direction to turn anti-clockwise.</param>
+        /// <returns>Anti-clockwise direction.</returns>
+        public static Direction Anticlockwise(this Direction direction)
+        {
+            return (Direction) ((int) direction + 1 % 4);
+        }
+
+        /// <summary>
+        /// Convert an X and Y displacement vector to the corresponding <see cref="Direction"/>.
+        /// </summary>
+        /// <param name="x">X magnitude.</param>
+        /// <param name="y">Y magnitude.</param>
+        /// <returns><see cref="Direction"/> of vector, or null if (x, y) is not a cardinal direction.</returns>
         public static Direction? GetDirection(int x, int y)
         {
-            if(x > 0 && y == 0) return Direction.Right;
-            if(x < 0 && y == 0) return Direction.Left;
-            if(x == 0 && y < 0) return Direction.Up;
-            if(x == 0 && y > 0) return Direction.Down;
+            if (x > 0 && y == 0) return Direction.Right;
+            if (x < 0 && y == 0) return Direction.Left;
+            if (x == 0 && y < 0) return Direction.Up;
+            if (x == 0 && y > 0) return Direction.Down;
 
             return null;
         }
 
-        public static Direction? GetDirection(Coordinates targetPosition, Coordinates myPosition)
+        /// <summary>
+        /// Find the <see cref="Direction"/> to travel from <paramref name="myPosition"/> to 
+        /// <paramref name="targetPosition"/>.
+        /// </summary>
+        /// <param name="myPosition">Original position.</param>
+        /// <param name="targetPosition">Desired destination.</param>
+        /// <returns>
+        /// <see cref="Direction"/> from <paramref name="myPosition"/> to <paramref name="targetPosition"/>, or null if 
+        /// <see cref="targetPosition"/> is not reachable via a cardinal direction.
+        /// </returns>
+        public static Direction? GetDirection(Coordinates myPosition, Coordinates targetPosition)
         {
             return GetDirection(targetPosition.X - myPosition.X, targetPosition.Y - myPosition.Y);
         }

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Shot.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Shot.cs
@@ -2,14 +2,31 @@
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// A shot on the <see cref="World"/>.
+    /// </summary>
     public class Shot
     {
+        /// <summary>
+        /// Shot movement per tick.
+        /// </summary>
         public const int Speed = 3;
-        
+
+        /// <summary>
+        /// Current tick position of the shot.
+        /// </summary>
         public Coordinates Position { get; }
+
+        /// <summary>
+        /// <see cref="Direction"/> that the shot is moving in.
+        /// </summary>
         public Direction Direction { get; }
-        
-        public Shot(Network network)
+
+        /// <summary>
+        /// Read a shot from the server tick response.
+        /// </summary>
+        /// <param name="network"><see cref="Network"/> to use to fetch data.</param>
+        internal Shot(Network network)
         {
             Position = new Coordinates(network);
             Direction = (Direction) network.ReadByte();

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Shot.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Shot.cs
@@ -1,0 +1,18 @@
+﻿using ScriptWars.Connection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public class Shot
+    {
+        public const int Speed = 3;
+        
+        public Coordinates Position { get; }
+        public Direction Direction { get; }
+        
+        public Shot(Network network)
+        {
+            Position = new Coordinates(network);
+            Direction = (Direction) network.ReadByte();
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Tank.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Tank.cs
@@ -1,0 +1,16 @@
+﻿using ScriptWars.Connection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public class Tank
+    {
+        public Coordinates Position { get; }
+        public int ClientId { get; }
+        
+        public Tank(Network network)
+        {
+            Position = new Coordinates(network);
+            ClientId = network.ReadByte();
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Tank.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/Tank.cs
@@ -2,12 +2,26 @@
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// A tank on the <see cref="World"/>.
+    /// </summary>
     public class Tank
     {
+        /// <summary>
+        /// Current tick position of the tank.
+        /// </summary>
         public Coordinates Position { get; }
+
+        /// <summary>
+        /// ID of the tank owner.
+        /// </summary>
         public int ClientId { get; }
-        
-        public Tank(Network network)
+
+        /// <summary>
+        /// Read a tank from the server tick response.
+        /// </summary>
+        /// <param name="network"><see cref="Network"/> to use to fetch data.</param>
+        internal Tank(Network network)
         {
             Position = new Coordinates(network);
             ClientId = network.ReadByte();

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/TankApi.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/TankApi.cs
@@ -4,21 +4,64 @@ using ScriptWars.Connection;
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// API to interface with the Tanks game on Script Wars.
+    /// </summary>
     public class TankApi
     {
+        /// <summary>
+        /// Current tick's selected <see cref="Action"/>.
+        /// </summary>
         public Action Action { get; private set; } = Action.Nothing;
+
+        /// <summary>
+        /// Whether or not this client is alive for the current tick.
+        /// </summary>
         public bool IsAlive { get; private set; }
+
+        /// <summary>
+        /// Available ammunition at start of the current tick.
+        /// </summary>
         public int Ammo { get; private set; }
+
+        /// <summary>
+        /// Direction of current tick's Move or Shoot <see cref="Action"/>.
+        /// </summary>
         public Direction Direction { get; private set; }
+
+        /// <summary>
+        /// <see cref="World"/> data as at the current tick.
+        /// </summary>
         public World Map { get; private set; }
+
+        /// <summary>
+        /// Current position at the start of the current tick.
+        /// </summary>
         public Coordinates Position { get; private set; }
 
+        /// <summary>
+        /// Current tick connection status.
+        /// </summary>
         public ConnectionStatus ConnectionStatus => _network.ConnectionStatus;
+
+        /// <summary>
+        /// All tanks in line-of-sight to the client for this tick.
+        /// </summary>
         public ICollection<Tank> VisibleTanks => Map.Tanks;
+
+        /// <summary>
+        /// All shots in flight this tick.
+        /// </summary>
         public ICollection<Shot> VisibleShots => Map.Shots;
 
         private readonly Network _network;
 
+        /// <summary>
+        /// Establish a connection to a Script Wars tanks server.
+        /// </summary>
+        /// <param name="id">Bot ID issued by the server.</param>
+        /// <param name="serverAddress">IP or domain of the server.</param>
+        /// <param name="tankName">Tank vanity name.</param>
         public TankApi(int id, string serverAddress, string tankName)
         {
             _network = new Network(id, serverAddress, tankName);
@@ -26,16 +69,20 @@ namespace ScriptWars.Games.Tanks
 
         private void SetSendData()
         {
-            _network.Send((byte)(int) Action);
+            _network.Send((byte) (int) Action);
 
             if (Action != Action.Nothing)
             {
-                _network.Send((byte)(int) Direction);
+                _network.Send((byte) (int) Direction);
             }
-            
+
             Action = Action.Nothing;
         }
 
+        /// <summary>
+        /// Wait for server tick and update client-side game state.
+        /// </summary>
+        /// <returns>Whether or not the connection and game are still active.</returns>
         public bool NextTick()
         {
             SetSendData();
@@ -49,6 +96,7 @@ namespace ScriptWars.Games.Tanks
 
             if (IsAlive)
             {
+                DoNothing();
                 Ammo = _network.ReadByte();
                 Position = new Coordinates(_network);
                 Map = new World(_network);
@@ -62,23 +110,37 @@ namespace ScriptWars.Games.Tanks
             return true;
         }
 
+        /// <summary>
+        /// Issue a move <see cref="Action"/> for this tick.
+        /// </summary>
+        /// <param name="direction"><see cref="Direction"/> to move in.</param>
         public void Move(Direction direction)
         {
             Action = Action.Move;
             Direction = direction;
         }
 
+        /// <summary>
+        /// Issue a shoot <see cref="Action"/> for this tick.
+        /// </summary>
+        /// <param name="direction"><see cref="Direction"/> to shoot in.</param>
         public void Shoot(Direction direction)
         {
             Action = Action.Shoot;
             Direction = direction;
         }
 
+        /// <summary>
+        /// Do nothing this tick.
+        /// </summary>
         public void DoNothing()
         {
             Action = Action.Nothing;
         }
 
+        /// <summary>
+        /// Print the current action for this tick.
+        /// </summary>
         public void PrintAction()
         {
             var direction = Action == Action.Nothing ? "" : Direction.ToString();

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/TankApi.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/TankApi.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using ScriptWars.Connection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public class TankApi
+    {
+        public Action Action { get; private set; } = Action.Nothing;
+        public bool IsAlive { get; private set; }
+        public int Ammo { get; private set; }
+        public Direction Direction { get; private set; }
+        public World Map { get; private set; }
+        public Coordinates Position { get; private set; }
+
+        public ConnectionStatus ConnectionStatus => _network.ConnectionStatus;
+        public ICollection<Tank> VisibleTanks => Map.Tanks;
+        public ICollection<Shot> VisibleShots => Map.Shots;
+
+        private readonly Network _network;
+
+        public TankApi(int id, string serverAddress, string tankName)
+        {
+            _network = new Network(id, serverAddress, tankName);
+        }
+
+        private void SetSendData()
+        {
+            _network.Send((byte)(int) Action);
+
+            if (Action != Action.Nothing)
+            {
+                _network.Send((byte)(int) Direction);
+            }
+            
+            Action = Action.Nothing;
+        }
+
+        public bool NextTick()
+        {
+            SetSendData();
+
+            if (!_network.NextTick())
+            {
+                return false;
+            }
+
+            IsAlive = _network.ReadByte() == 1;
+
+            if (IsAlive)
+            {
+                Ammo = _network.ReadByte();
+                Position = new Coordinates(_network);
+                Map = new World(_network);
+            }
+            else
+            {
+                Position = null;
+                Map = null;
+            }
+
+            return true;
+        }
+
+        public void Move(Direction direction)
+        {
+            Action = Action.Move;
+            Direction = direction;
+        }
+
+        public void Shoot(Direction direction)
+        {
+            Action = Action.Shoot;
+            Direction = direction;
+        }
+
+        public void DoNothing()
+        {
+            Action = Action.Nothing;
+        }
+
+        public void PrintAction()
+        {
+            var direction = Action == Action.Nothing ? "" : Direction.ToString();
+            Console.WriteLine($"{Action} {direction}");
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -5,26 +5,57 @@ using ScriptWars.Connection;
 
 namespace ScriptWars.Games.Tanks
 {
+    /// <summary>
+    /// The world map.
+    /// </summary>
     public class World
     {
-        public bool[,] Map { get; }
+        /// <summary>
+        /// The width of the map in squares.
+        /// </summary>
+        public int Width => _map.GetLength(0);
+
+        /// <summary>
+        /// The height of the map in squares.
+        /// </summary>
+        public int Height => _map.GetLength(1);
+
+        /// <summary>
+        /// Positions of all ammo packs on the map.
+        /// </summary>
         public ICollection<Coordinates> AmmoLocations { get; }
+
+        /// <summary>
+        /// All <see cref="Tank"/> visible to the client.
+        /// </summary>
         public ICollection<Tank> Tanks { get; }
+
+        /// <summary>
+        /// All <see cref="Shot"/> visible to the client.
+        /// </summary>
         public ICollection<Shot> Shots { get; }
 
+        private readonly bool[,] _map;
         private readonly IDictionary<Coordinates, Tank> _tankMap = new Dictionary<Coordinates, Tank>();
 
+        /// <summary>
+        /// Read the game world from the server tick response.
+        /// </summary>
+        /// <param name="network"><see cref="Network"/> to use to fetch data.</param>
         public World(Network network)
         {
+            // Map dimensions
             int width = network.ReadByte();
             int height = network.ReadByte();
 
-            Map = new bool[width, height];
+            _map = new bool[width, height];
 
-            for (var i = 0; i < Map.GetLength(0); i++)
-            for (var j = 0; j < Map.GetLength(1); j++)
-                Map[i, j] = network.ReadBool();
+            // Wall positions
+            for (var i = 0; i < _map.GetLength(0); i++)
+            for (var j = 0; j < _map.GetLength(1); j++)
+                _map[i, j] = network.ReadBool();
 
+            // Tanks
             int tankCount = network.ReadByte();
             for (var i = 0; i < tankCount; i++)
             {
@@ -33,6 +64,7 @@ namespace ScriptWars.Games.Tanks
             }
             Tanks = new ReadOnlyCollection<Tank>(_tankMap.Values.ToList());
 
+            // Shots
             int shotCount = network.ReadByte();
             var shots = new List<Shot>();
             for (var i = 0; i < shotCount; i++)
@@ -42,6 +74,7 @@ namespace ScriptWars.Games.Tanks
             }
             Shots = new ReadOnlyCollection<Shot>(shots);
 
+            // Ammo
             int ammoCount = network.ReadByte();
             var ammoLocations = new List<Coordinates>();
             for (var i = 0; i < ammoCount; i++)
@@ -52,14 +85,24 @@ namespace ScriptWars.Games.Tanks
             AmmoLocations = new ReadOnlyCollection<Coordinates>(ammoLocations);
         }
 
+        /// <summary>
+        /// Get the <see cref="Tank"/> at a particular position.
+        /// </summary>
+        /// <param name="position">Position to look for a <see cref="Tank"/> at.</param>
+        /// <returns><see cref="Tank"/> data or null if there is no tank at <paramref name="position"/>.</returns>
         public Tank GetTank(Coordinates position)
         {
             return _tankMap.TryGetValue(position, out var tank) ? tank : null;
         }
 
+        /// <summary>
+        /// Check if a particular position is a wall or open ground.
+        /// </summary>
+        /// <param name="position">Position to check for wall block.</param>
+        /// <returns>Whether or not <paramref name="position"/> holds a wall.</returns>
         public bool IsWall(Coordinates position)
         {
-            return Map[position.X, position.Y];
+            return _map[position.X, position.Y];
         }
     }
 }

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -13,12 +13,12 @@ namespace ScriptWars.Games.Tanks
         /// <summary>
         /// The width of the map in squares.
         /// </summary>
-        public int Width => _map.GetLength(0);
+        public int Width => _map.GetLength(1);
 
         /// <summary>
         /// The height of the map in squares.
         /// </summary>
-        public int Height => _map.GetLength(1);
+        public int Height => _map.GetLength(0);
 
         /// <summary>
         /// Positions of all ammo packs on the map.
@@ -48,12 +48,12 @@ namespace ScriptWars.Games.Tanks
             int width = network.ReadByte();
             int height = network.ReadByte();
 
-            _map = new bool[width, height];
+            _map = new bool[height, width];
 
             // Wall positions
-            for (var i = 0; i < Width; i++)
-            for (var j = 0; j < Height; j++)
-                _map[j, i] = network.ReadBool();
+            for (var i = 0; i < Height; i++)
+            for (var j = 0; j < Width; j++)
+                _map[i, j] = network.ReadBool();
 
             // Tanks
             int tankCount = network.ReadByte();
@@ -102,7 +102,7 @@ namespace ScriptWars.Games.Tanks
         /// <returns>Whether or not <paramref name="position"/> holds a wall.</returns>
         public bool IsWall(Coordinates position)
         {
-            return _map[position.X, position.Y];
+            return _map[position.Y, position.X];
         }
     }
 }

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -37,6 +37,7 @@ namespace ScriptWars.Games.Tanks
 
         private readonly bool[,] _map;
         private readonly IDictionary<Coordinates, Tank> _tankMap = new Dictionary<Coordinates, Tank>();
+        private readonly IDictionary<Coordinates, Shot> _shotMap = new Dictionary<Coordinates, Shot>();
 
         /// <summary>
         /// Read the game world from the server tick response.
@@ -66,13 +67,12 @@ namespace ScriptWars.Games.Tanks
 
             // Shots
             int shotCount = network.ReadByte();
-            var shots = new List<Shot>();
             for (var i = 0; i < shotCount; i++)
             {
                 var shot = new Shot(network);
-                shots.Add(shot);
+                _shotMap.Add(shot.Position, shot);
             }
-            Shots = new ReadOnlyCollection<Shot>(shots);
+            Shots = new ReadOnlyCollection<Shot>(_shotMap.Values.ToList());
 
             // Ammo
             int ammoCount = network.ReadByte();
@@ -93,6 +93,16 @@ namespace ScriptWars.Games.Tanks
         public Tank GetTank(Coordinates position)
         {
             return _tankMap.TryGetValue(position, out var tank) ? tank : null;
+        }
+
+        /// <summary>
+        /// Get the <see cref="Shot"/> at a particular position.
+        /// </summary>
+        /// <param name="position">Position to look for a <see cref="Shot"/> at.</param>
+        /// <returns><see cref="Shot"/> data or null if there is no shot at <paramref name="position"/>.</returns>
+        public Shot GetShot(Coordinates position)
+        {
+            return _shotMap.TryGetValue(position, out var shot) ? shot : null;
         }
 
         /// <summary>

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -51,8 +51,8 @@ namespace ScriptWars.Games.Tanks
             _map = new bool[width, height];
 
             // Wall positions
-            for (var i = 0; i < _map.GetLength(0); i++)
-            for (var j = 0; j < _map.GetLength(1); j++)
+            for (var i = 0; i < Width; i++)
+            for (var j = 0; j < Height; j++)
                 _map[j, i] = network.ReadBool();
 
             // Tanks

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using ScriptWars.Connection;
+
+namespace ScriptWars.Games.Tanks
+{
+    public class World
+    {
+        public bool[,] Map { get; }
+        public ICollection<Coordinates> AmmoLocations { get; }
+        public ICollection<Tank> Tanks { get; }
+        public ICollection<Shot> Shots { get; }
+
+        private readonly IDictionary<Coordinates, Tank> _tankMap = new Dictionary<Coordinates, Tank>();
+
+        public World(Network network)
+        {
+            int width = network.ReadByte();
+            int height = network.ReadByte();
+
+            Map = new bool[width, height];
+
+            for (var i = 0; i < Map.GetLength(0); i++)
+            for (var j = 0; j < Map.GetLength(1); j++)
+                Map[i, j] = network.ReadBool();
+
+            int tankCount = network.ReadByte();
+            for (var i = 0; i < tankCount; i++)
+            {
+                var tank = new Tank(network);
+                _tankMap.Add(tank.Position, tank);
+            }
+            Tanks = new ReadOnlyCollection<Tank>(_tankMap.Values.ToList());
+
+            int shotCount = network.ReadByte();
+            var shots = new List<Shot>();
+            for (var i = 0; i < shotCount; i++)
+            {
+                var shot = new Shot(network);
+                shots.Add(shot);
+            }
+            Shots = new ReadOnlyCollection<Shot>(shots);
+
+            int ammoCount = network.ReadByte();
+            var ammoLocations = new List<Coordinates>();
+            for (var i = 0; i < ammoCount; i++)
+            {
+                var ammo = new Coordinates(network);
+                ammoLocations.Add(ammo);
+            }
+            AmmoLocations = new ReadOnlyCollection<Coordinates>(ammoLocations);
+        }
+
+        public Tank GetTank(Coordinates position)
+        {
+            return _tankMap.TryGetValue(position, out var tank) ? tank : null;
+        }
+
+        public bool IsWall(Coordinates position)
+        {
+            return Map[position.X, position.Y];
+        }
+    }
+}

--- a/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
+++ b/client/csharp/Script Wars Client/Script Wars Client/ScriptWars/Games/Tanks/World.cs
@@ -53,7 +53,7 @@ namespace ScriptWars.Games.Tanks
             // Wall positions
             for (var i = 0; i < _map.GetLength(0); i++)
             for (var j = 0; j < _map.GetLength(1); j++)
-                _map[i, j] = network.ReadBool();
+                _map[j, i] = network.ReadBool();
 
             // Tanks
             int tankCount = network.ReadByte();


### PR DESCRIPTION
To use it, just create a solution (or re-use the existing solution provided) and add an executable project that references the `Script Wars Client` class library project. One nuget package will need to be restored (provides a `BinaryReader` and `BinaryWriter` that handle big-endian data).

Framework level used is .NET Standard 1.6 (depends on the open source .NET Core, rather than the proprietary .NET Framework).

The API is modelled to be very close to the Java one as I basically just translated the Java client, but takes advantages of some C# syntactic sugar like getters and setters. Class names are identical and equivalent to their Java counterparts.

**Update:** hold off on merging until I add inline docs for the rest of the code. Got caught up in solving the bug with the endianness that I forgot docstrings aren't done.